### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/setup-openfoam/security/code-scanning/2](https://github.com/gerlero/setup-openfoam/security/code-scanning/2)

To fix this problem, add an explicit `permissions` block set to the minimum required access—here, `contents: read`—to the workflow. The best practice is to add this at the root of the workflow YAML so that it applies to all jobs unless specifically overridden. This can be done on a new line immediately after the workflow `name` field and before the `on:` key in `.github/workflows/ci.yml`. No additional permissions seem necessary based on the steps listed for each job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
